### PR TITLE
Ordbog kommando.

### DIFF
--- a/concieggs/compiled/forklar.fs
+++ b/concieggs/compiled/forklar.fs
@@ -25,7 +25,7 @@ let main argv =
 
 
     let startTag = """<span class="definition">"""
-    let endTag = """</span>"""    
+    let endTag = """<"""    
     
     let startIndex = (doc.IndexOf(startTag)) + startTag.Length
     let lastIndex = doc.Length-1

--- a/concieggs/compiled/forklar.fs
+++ b/concieggs/compiled/forklar.fs
@@ -1,0 +1,41 @@
+﻿open System.Net
+open System
+open System.IO
+[<EntryPoint>]
+let main argv = 
+    
+    //tyvstjålet fra fsharpforfunandprofit
+    let fetchUrl callback url =
+        let request = WebRequest.Create(Uri(url)) 
+        use resp = request.GetResponse() 
+        use stream = resp.GetResponseStream() 
+        use reader = new IO.StreamReader(stream)
+        callback reader url
+    let myCallback (reader:IO.StreamReader) url = 
+        let html = reader.ReadToEnd()
+        html      // return all the html
+    //resten er OC, jeg lover det
+        
+        
+    let baseUrl = "https://ordnet.dk/ddo/ordbog?query="
+    let query = argv.[0]
+    
+    let url = baseUrl + query
+    let doc = fetchUrl myCallback url
+
+
+    let startTag = """<span class="definition">"""
+    let endTag = """</span>"""    
+    
+    let startIndex = (doc.IndexOf(startTag)) + startTag.Length
+    let lastIndex = doc.Length-1
+    let cutDoc = doc.[startIndex..lastIndex]
+    let endIndex = startIndex + cutDoc.IndexOf(endTag)
+
+    printfn "%s" (query + " betyder: " + doc.[startIndex..endIndex-1] + ".")
+    0
+    
+    
+    
+    
+    


### PR DESCRIPTION
Tager et argument, som den prøver at slå op på ordnet.dk, hvorefter den giver den første definition.